### PR TITLE
Refine: UX, Accessibility, and Mobile Layout Improvements

### DIFF
--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -59,20 +59,12 @@ export function OutlineBlock({
     onChange(newContent)
   }
 
-  const getBlockStyles = (type: string, hasContent: boolean) => {
+  const getBlockStyles = (hasContent: boolean) => {
     const base = "w-full min-h-[40px] sm:min-h-[50px] p-3 sm:p-4 rounded-xl transition-all duration-300 border"
-    if (!hasContent) return cn(base, "bg-muted/10 border-primary/10 hover:bg-muted/20 hover:border-primary/20")
-
-    switch (type) {
-      case "intro":
-        return cn(base, "bg-background/50 border-primary/10 hover:bg-background/70 hover:border-primary/20")
-      case "body":
-        return cn(base, "bg-background/50 border-primary/10 hover:bg-background/70 hover:border-primary/20")
-      case "conclusion":
-        return cn(base, "bg-background/50 border-primary/10 hover:bg-background/70 hover:border-primary/20")
-      default:
-        return cn(base, "bg-muted/10 border-primary/10 hover:bg-muted/20")
+    if (!hasContent) {
+      return cn(base, "bg-muted/10 border-primary/10 hover:bg-muted/20 hover:border-primary/20")
     }
+    return cn(base, "bg-background/50 border-primary/10 hover:bg-background/70 hover:border-primary/20")
   }
 
   return (
@@ -109,8 +101,8 @@ export function OutlineBlock({
                 onChange={onLabelChange}
                 as="label"
                 ariaLabel={`Block label: ${block.label}`}
-                className="text-[9px] sm:text-[10px] font-black uppercase tracking-[0.15em] sm:tracking-[0.2em] text-muted-foreground transition-colors hover:text-foreground/80 truncate block"
-                inputClassName="text-[9px] sm:text-[10px] font-black uppercase tracking-[0.15em] sm:tracking-[0.2em] h-5 w-full"
+                className="text-[10px] sm:text-[11px] font-black uppercase tracking-[0.1em] sm:tracking-[0.2em] text-muted-foreground transition-colors hover:text-foreground/80 truncate block"
+                inputClassName="text-[10px] sm:text-[11px] font-black uppercase tracking-[0.1em] sm:tracking-[0.2em] h-5 w-full"
               />
             </div>
 
@@ -148,14 +140,14 @@ export function OutlineBlock({
                 onBlur={() => setIsEditing(false)}
                 aria-label={`Editing content for ${block.label}`}
                 className={cn(
-                  getBlockStyles(block.type, true),
+                  getBlockStyles(true),
                   "focus:outline-none focus:ring-2 focus:ring-ring/20 resize-none overflow-hidden text-sm shadow-inner-soft border-primary/30"
                 )}
                 placeholder={block.placeholder}
               />
             ) : (
               <div
-                className={cn(getBlockStyles(block.type, !!block.content), "cursor-text focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-offset-2 outline-none flex items-start gap-2 hover:bg-primary/[0.03]")}
+                className={cn(getBlockStyles(!!block.content), "cursor-text focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:ring-offset-2 outline-none flex items-start gap-2 hover:bg-primary/[0.03]")}
                 tabIndex={0}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' || e.key === ' ') {

--- a/components/outline-section.tsx
+++ b/components/outline-section.tsx
@@ -52,10 +52,10 @@ export function OutlineSection({
       "overflow-hidden border-1.5 sm:border-2 shadow-soft transition-all duration-300 bg-background"
     )}>
       <CardHeader className={cn(
-        "flex flex-row items-center justify-between space-y-0 px-4 py-3 sm:px-6 sm:py-4 gap-2",
+        "flex flex-col sm:flex-row sm:items-center justify-between space-y-3 sm:space-y-0 px-4 py-3 sm:px-6 sm:py-4 gap-2",
         isDraggable && "pl-11 sm:pl-14"
       )}>
-        <div className="flex items-center gap-2 sm:gap-3 overflow-hidden min-w-0 flex-1 sm:flex-none">
+        <div className="flex items-center gap-2 sm:gap-3 overflow-hidden min-w-0 flex-1">
           <EditableText
             value={section.title}
             onChange={(newTitle) => onTitleChange(sectionIndex, newTitle)}
@@ -66,26 +66,26 @@ export function OutlineSection({
           />
         </div>
 
-        <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0 ml-auto">
+        <div className="flex items-center gap-2 flex-wrap sm:flex-nowrap sm:ml-auto">
           <Button
             variant="ghost"
             size="sm"
             onClick={() => onResetTitle(sectionIndex)}
-            className="h-8 w-8 sm:w-auto gap-1.5 px-0 sm:px-2 text-[10px] font-bold uppercase text-muted-foreground/70 hover:text-primary hover:bg-primary/5"
+            className="h-9 sm:h-8 px-2 sm:px-2 gap-1.5 text-[10px] font-bold uppercase text-muted-foreground/70 hover:text-primary hover:bg-primary/5"
             title="Reset Title"
           >
             <RefreshCw className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">Reset Title</span>
+            <span className="sm:inline">Reset Title</span>
           </Button>
 
           <Button
             variant="secondary"
             size="sm"
             onClick={onAddBlock}
-            className="h-8 w-8 sm:w-auto gap-1.5 px-0 sm:px-3 text-[10px] font-black uppercase tracking-wider shadow-sm rounded-lg"
+            className="h-9 sm:h-8 px-3 sm:px-3 gap-1.5 text-[10px] font-black uppercase tracking-wider shadow-sm rounded-lg"
           >
             <Plus className="h-3 w-3" />
-            <span className="hidden sm:inline">Add Block</span>
+            <span className="sm:inline">Add Block</span>
           </Button>
 
           {section.type === "body" && (
@@ -93,7 +93,7 @@ export function OutlineSection({
               variant="ghost"
               size="icon"
               onClick={onRemoveSection}
-              className="h-7 w-7 text-muted-foreground/60 hover:bg-destructive/10 hover:text-destructive"
+              className="h-9 w-9 sm:h-7 sm:w-7 text-muted-foreground/60 hover:bg-destructive/10 hover:text-destructive"
               title="Remove Section"
             >
               <X className="h-3.5 w-3.5" />

--- a/components/ui/editable-text.tsx
+++ b/components/ui/editable-text.tsx
@@ -79,7 +79,7 @@ export function EditableText({
         onClick={() => setIsEditing(true)}
         aria-label={ariaLabel || (value ? `Edit ${value}` : "Edit empty text")}
         className={cn(
-          "text-left cursor-pointer hover:bg-accent/20 rounded px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 border border-primary/10 hover:border-primary/30 min-w-[40px] truncate",
+          "text-left cursor-pointer hover:bg-accent/20 rounded px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 border border-primary/10 hover:border-primary/30 min-w-[40px] truncate",
           className
         )}
       >
@@ -88,7 +88,7 @@ export function EditableText({
         </Component>
       </button>
       {showEditIcon && (
-        <Pencil className="h-3 w-3 text-primary/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex-shrink-0" />
+        <Pencil className="h-3 w-3 text-primary/40 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity flex-shrink-0" />
       )}
     </div>
   )


### PR DESCRIPTION
This PR implements a set of focused improvements to the Drag & Draft essay planner, focusing on mobile UX, accessibility, and code quality.

Key changes:
- **UX & Accessibility**: Made edit icons always visible on mobile in `EditableText` (as hover isn't available) and improved focus ring contrast.
- **Mobile Responsiveness**: Reorganized the `OutlineSection` header to prevent overcrowding on small screens and increased button heights for better touch targets.
- **Code Quality**: Refactored `getBlockStyles` in `OutlineBlock` to remove redundant identical styles for different section types, adhering to DRY principles.
- **Visuals**: Slightly increased label font sizes and adjusted tracking for better legibility on mobile.

Verified with Playwright tests and visual inspection on both desktop and mobile viewports.

---
*PR created automatically by Jules for task [2028972178842542020](https://jules.google.com/task/2028972178842542020) started by @allemandi*