### PR TITLE
Refine: Interaction & Export UX Improvements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { Button } from "@/components/ui/button"
 import { Layout, Save, Plus, Moon, Sun, RefreshCw } from "lucide-react"
 import { useTheme } from "next-themes"
 import Footer from "@/components/footer"
-import { formatOutline, downloadFile } from "@/lib/utils"
+import { formatOutline, downloadFile, copyToClipboard } from "@/lib/utils"
 import { ExportModal } from "@/components/export-modal"
 import { BackupModal } from "@/components/backup-modal"
 import { useOutline } from "@/hooks/use-outline"
@@ -128,6 +128,25 @@ export default function EssayOutlinePlanner() {
   const handleExport = (format: "pdf" | "docx" | "txt" | "md") => {
     const formatted = formatOutline(sections, format)
     downloadFile(formatted, format)
+  }
+
+  const handleCopy = async (format: "txt" | "md") => {
+    const formatted = (await formatOutline(sections, format)) as string
+    const success = await copyToClipboard(formatted)
+    if (success) {
+      toast({
+        title: "Copied to Clipboard",
+        description: `Outline copied in ${format === "md" ? "Markdown" : "Plain Text"} format.`,
+        duration: 3000,
+      })
+    } else {
+      toast({
+        title: "Copy Failed",
+        description: "Could not copy to clipboard. Please try again.",
+        variant: "destructive",
+        duration: 3000,
+      })
+    }
   }
 
   const handleBackupDownload = () => {
@@ -244,7 +263,7 @@ export default function EssayOutlinePlanner() {
                   onDownload={handleBackupDownload}
                   onUpload={() => fileInputRef.current?.click()}
                 />
-                <ExportModal onExport={handleExport} />
+                <ExportModal onExport={handleExport} onCopy={handleCopy} />
                 <Button
                   variant="outline"
                   size="sm"

--- a/components/export-modal.tsx
+++ b/components/export-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileText, AlignLeft, Download, FileCode } from "lucide-react";
+import { FileText, AlignLeft, Download, FileCode, Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -13,9 +13,10 @@ import {
 
 interface ExportModalProps {
   onExport: (format: "pdf" | "docx" | "txt" | "md") => void;
+  onCopy: (format: "txt" | "md") => void;
 }
 
-export function ExportModal({ onExport }: ExportModalProps) {
+export function ExportModal({ onExport, onCopy }: ExportModalProps) {
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -48,22 +49,42 @@ export function ExportModal({ onExport }: ExportModalProps) {
             <FileText className="h-5 w-5 mb-1.5 text-blue-500/80" />
             <span className="text-[11px] font-bold tracking-widest">WORD</span>
           </Button>
-          <Button
-            onClick={() => onExport("txt")}
-            variant="outline"
-            className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-slate-500/[0.03] hover:border-slate-500/20"
-          >
-            <AlignLeft className="h-5 w-5 mb-1.5 text-slate-500/80" />
-            <span className="text-[11px] font-bold tracking-widest">TEXT</span>
-          </Button>
-          <Button
-            onClick={() => onExport("md")}
-            variant="outline"
-            className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-emerald-500/[0.03] hover:border-emerald-500/20"
-          >
-            <FileCode className="h-5 w-5 mb-1.5 text-emerald-500/80" />
-            <span className="text-[11px] font-bold tracking-widest">MARKDOWN</span>
-          </Button>
+          <div className="flex flex-col gap-2">
+            <Button
+              onClick={() => onExport("txt")}
+              variant="outline"
+              className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-slate-500/[0.03] hover:border-slate-500/20 w-full"
+            >
+              <AlignLeft className="h-5 w-5 mb-1.5 text-slate-500/80" />
+              <span className="text-[11px] font-bold tracking-widest">TEXT</span>
+            </Button>
+            <Button
+              onClick={() => onCopy("txt")}
+              variant="ghost"
+              className="h-8 text-[9px] font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+            >
+              <Copy className="h-3 w-3 mr-1.5" />
+              Copy to clipboard
+            </Button>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Button
+              onClick={() => onExport("md")}
+              variant="outline"
+              className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-emerald-500/[0.03] hover:border-emerald-500/20 w-full"
+            >
+              <FileCode className="h-5 w-5 mb-1.5 text-emerald-500/80" />
+              <span className="text-[11px] font-bold tracking-widest">MARKDOWN</span>
+            </Button>
+            <Button
+              onClick={() => onCopy("md")}
+              variant="ghost"
+              className="h-8 text-[9px] font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+            >
+              <Copy className="h-3 w-3 mr-1.5" />
+              Copy to clipboard
+            </Button>
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -71,6 +71,8 @@ export function OutlineBlock({
     return cn(base, "bg-background/50 border-primary/10 hover:bg-background/70 hover:border-primary/20 hover:shadow-inner")
   }
 
+  const wordCount = block.content.trim().split(/\s+/).filter(Boolean).length
+
   return (
     <div
       ref={setNodeRef}
@@ -136,7 +138,7 @@ export function OutlineBlock({
             </div>
           </div>
 
-          <div className="w-full relative group/content" onClick={() => setIsEditing(true)}>
+          <div className="w-full relative group/content">
             {isEditing ? (
               <textarea
                 ref={textareaRef}
@@ -151,52 +153,73 @@ export function OutlineBlock({
                 placeholder={block.placeholder}
               />
             ) : (
-              <div
-                className={cn(
-                  getBlockStyles(!!block.content),
-                  "cursor-text focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none flex items-start gap-2 hover:bg-primary/[0.03] relative"
-                )}
-                tabIndex={0}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    setIsEditing(true);
-                  }
-                }}
-                role="button"
-                aria-label={`Edit content for ${block.label}. ${block.content ? 'Current content: ' + block.content.substring(0, 50) + '...' : 'Currently empty.'}`}
-              >
-                <div className="flex-grow min-h-[20px]">
-                  {block.content ? (
-                    <p className="whitespace-pre-line text-sm leading-relaxed text-foreground/90">
-                      {block.content}
-                    </p>
-                  ) : (
-                    <p className="text-sm text-muted-foreground/70 italic whitespace-pre-line">
-                      {block.placeholder}
-                    </p>
+              <>
+                <div
+                  className={cn(
+                    getBlockStyles(!!block.content),
+                    "cursor-text focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 outline-none flex items-start gap-2 hover:bg-primary/[0.03] relative"
                   )}
+                  tabIndex={0}
+                  onClick={() => setIsEditing(true)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setIsEditing(true);
+                    }
+                  }}
+                  role="button"
+                  aria-label={`Edit content for ${block.label}. ${block.content ? 'Current content: ' + block.content.substring(0, 50) + '...' : 'Currently empty.'}`}
+                >
+                  <div className="flex-grow min-h-[20px]">
+                    {block.content ? (
+                      <p className="whitespace-pre-line text-sm leading-relaxed text-foreground/90">
+                        {block.content}
+                      </p>
+                    ) : (
+                      <p className="text-sm text-muted-foreground/70 italic whitespace-pre-line">
+                        {block.placeholder}
+                      </p>
+                    )}
+                  </div>
                 </div>
-                <div className="absolute right-3 top-3 flex items-center gap-1 opacity-0 group-hover/content:opacity-100 transition-opacity">
+                <div className="absolute right-3 top-3 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover/content:opacity-100 transition-opacity">
                   {block.content && (
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onChange(blockIndex, "")
-                      }}
+                      onClick={() => onChange(blockIndex, "")}
                       className="h-6 w-6 text-muted-foreground/40 hover:text-destructive hover:bg-destructive/5 rounded-md"
                       title="Clear Content"
+                      aria-label="Clear block content"
                     >
                       <X className="h-3 w-3" />
                     </Button>
                   )}
-                  <Pencil className="h-3 w-3 text-primary/40" />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setIsEditing(true)}
+                    className="h-6 w-6 text-primary/40 hover:text-primary hover:bg-primary/5 rounded-md"
+                    title="Edit Content"
+                    aria-label="Edit block content"
+                  >
+                    <Pencil className="h-3 w-3" />
+                  </Button>
                 </div>
-              </div>
+              </>
             )}
           </div>
+
+          {block.content && (
+            <div className="flex justify-end px-1">
+              <span
+                className="text-[9px] font-bold uppercase tracking-wider text-muted-foreground/50"
+                aria-label={`Word count: ${wordCount}`}
+              >
+                {wordCount} {wordCount === 1 ? "word" : "words"}
+              </span>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -214,3 +214,16 @@ function getMimeType(format: string): string {
   };
   return types[format] || "text/plain";
 }
+
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard) {
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch (err) {
+    console.error("Failed to copy: ", err);
+    return false;
+  }
+}


### PR DESCRIPTION
This PR implements several practical enhancements to the Drag & Draft application:

1. **Accessibility & Interaction Fixes**:
   - Refactored `OutlineBlock` to fix a nested interactive control violation. The "Clear" and "Edit" buttons are now separate from the main content trigger.
   - Enhanced ARIA labels and roles for better screen reader support.
   - Improved focus states and keyboard navigation for editing blocks.

2. **New UX Features**:
   - **Word Count**: Added a real-time word count indicator to each block, providing valuable feedback for essay planning.
   - **Copy to Clipboard**: Added a "Copy to Clipboard" option in the Export Modal for Markdown and Plain Text formats. This allows for quick extraction of the outline without downloading a file.

3. **Mobile Refinements**:
   - Ensured "Edit" and "Clear" affordances are always visible on touch devices, as hover states are not reliable on mobile.

All changes have been verified with existing Playwright tests and manual visual inspection (screenshots and video generated).

---
*PR created automatically by Jules for task [2640452158752825681](https://jules.google.com/task/2640452158752825681) started by @allemandi*