### PR TITLE
Refine: Outline Editing UX, Performance & Accessibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -90,7 +90,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground transition-colors duration-500 antialiased;
+    @apply bg-background text-foreground transition-colors duration-200 antialiased;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -348,6 +348,7 @@ export default function EssayOutlinePlanner() {
                   if (section.type !== "body") return null
                   return (
                     <MemoizedSortableSection key={section.id} id={section.id}>
+                      <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 fill-mode-both">
                       <MemoizedOutlineSection
                         section={section}
                         sectionIndex={idx}
@@ -366,6 +367,7 @@ export default function EssayOutlinePlanner() {
                         lastAddedId={lastAddedId}
                         setLastAddedId={setLastAddedId}
                       />
+                      </div>
                     </MemoizedSortableSection>
                   )
                 })}

--- a/components/export-modal.tsx
+++ b/components/export-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { FileText, AlignLeft, Download, FileCode, Copy } from "lucide-react";
+import { useState } from "react";
+import { FileText, AlignLeft, Download, FileCode, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -17,6 +18,14 @@ interface ExportModalProps {
 }
 
 export function ExportModal({ onExport, onCopy }: ExportModalProps) {
+  const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
+
+  const handleCopy = async (format: "txt" | "md") => {
+    onCopy(format);
+    setCopiedFormat(format);
+    setTimeout(() => setCopiedFormat(null), 2000);
+  };
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -59,12 +68,16 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
               <span className="text-[11px] font-bold tracking-widest">TEXT</span>
             </Button>
             <Button
-              onClick={() => onCopy("txt")}
-              variant="ghost"
-              className="h-8 text-[9px] font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+              onClick={() => handleCopy("txt")}
+              variant="secondary"
+              className="h-9 text-[10px] font-bold uppercase tracking-wider rounded-lg"
             >
-              <Copy className="h-3 w-3 mr-1.5" />
-              Copy to clipboard
+              {copiedFormat === "txt" ? (
+                <Check className="h-3.5 w-3.5 mr-1.5 text-emerald-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              {copiedFormat === "txt" ? "Copied!" : "Copy Text"}
             </Button>
           </div>
           <div className="flex flex-col gap-2">
@@ -77,12 +90,16 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
               <span className="text-[11px] font-bold tracking-widest">MARKDOWN</span>
             </Button>
             <Button
-              onClick={() => onCopy("md")}
-              variant="ghost"
-              className="h-8 text-[9px] font-bold uppercase tracking-wider text-muted-foreground hover:text-primary"
+              onClick={() => handleCopy("md")}
+              variant="secondary"
+              className="h-9 text-[10px] font-bold uppercase tracking-wider rounded-lg"
             >
-              <Copy className="h-3 w-3 mr-1.5" />
-              Copy to clipboard
+              {copiedFormat === "md" ? (
+                <Check className="h-3.5 w-3.5 mr-1.5 text-emerald-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5 mr-1.5" />
+              )}
+              {copiedFormat === "md" ? "Copied!" : "Copy MD"}
             </Button>
           </div>
         </div>

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -105,7 +105,7 @@ export function OutlineBlock({
       ref={setNodeRef}
       style={style}
       className={cn(
-        "group relative rounded-2xl border-1.5 sm:border-2 border-border/60 bg-card p-3 sm:p-4 transition-all duration-300 w-full min-w-0 overflow-hidden",
+        "group relative rounded-2xl border-1.5 sm:border-2 border-border/60 bg-card p-3 sm:p-4 transition-all duration-300 w-full min-w-0 overflow-hidden animate-in fade-in slide-in-from-bottom-2 duration-500 fill-mode-both",
         isDragging ? "z-50 shadow-md scale-[1.01] border-primary/20" : "shadow-soft hover:shadow-md hover:border-border"
       )}
     >

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import { useState, useRef, useEffect, useId } from "react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { GripVertical, X, RefreshCw, Pencil } from "lucide-react"
+import { GripVertical, X, RefreshCw, Pencil, Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { EditableText } from "@/components/ui/editable-text"
 import type { OutlineBlock as OutlineBlockType } from "@/lib/types"
@@ -33,6 +33,7 @@ export function OutlineBlock({
 }: OutlineBlockProps) {
   const dragDescId = useId()
   const [isEditing, setIsEditing] = useState(false)
+  const [tempContent, setTempContent] = useState(block.content)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -49,18 +50,44 @@ export function OutlineBlock({
   }
 
   useEffect(() => {
-    if (isEditing && textareaRef.current) {
-      textareaRef.current.focus()
-      textareaRef.current.style.height = "auto"
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
+    if (isEditing) {
+      setTempContent(block.content)
+      setTimeout(() => {
+        if (textareaRef.current) {
+          textareaRef.current.focus()
+          textareaRef.current.style.height = "auto"
+          textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
+        }
+      }, 0)
     }
-  }, [isEditing])
+  }, [isEditing, block.content])
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newContent = e.target.value
+    setTempContent(newContent)
     e.target.style.height = "auto"
     e.target.style.height = `${e.target.scrollHeight}px`
-    onChange(blockIndex, newContent)
+  }
+
+  const handleBlur = (e?: React.FocusEvent | React.MouseEvent) => {
+    // If we're blurring because of an Escape key press, we don't want to save
+    if (isEditing) {
+      setIsEditing(false)
+      if (tempContent !== block.content) {
+        onChange(blockIndex, tempContent)
+      }
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleBlur()
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      setTempContent(block.content)
+      setIsEditing(false)
+    }
   }
 
   const getBlockStyles = (hasContent: boolean) => {
@@ -140,18 +167,37 @@ export function OutlineBlock({
 
           <div className="w-full relative group/content">
             {isEditing ? (
-              <textarea
-                ref={textareaRef}
-                value={block.content}
-                onChange={handleContentChange}
-                onBlur={() => setIsEditing(false)}
-                aria-label={`Editing content for ${block.label}`}
-                className={cn(
-                  getBlockStyles(true),
-                  "focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden text-sm shadow-inner-soft border-primary/40 bg-background"
-                )}
-                placeholder={block.placeholder}
-              />
+              <div className="relative">
+                <textarea
+                  ref={textareaRef}
+                  value={tempContent}
+                  onChange={handleContentChange}
+                  onBlur={handleBlur}
+                  onKeyDown={handleKeyDown}
+                  aria-label={`Editing content for ${block.label}`}
+                  className={cn(
+                    getBlockStyles(true),
+                    "focus:outline-none focus:ring-2 focus:ring-primary/30 resize-none overflow-hidden text-sm shadow-inner-soft border-primary/40 bg-background pb-10"
+                  )}
+                  placeholder={block.placeholder}
+                />
+                <div className="absolute bottom-2 right-2 flex items-center gap-2">
+                   <span className="text-[10px] text-muted-foreground hidden sm:inline-block mr-2">
+                    Ctrl + Enter to save
+                  </span>
+                  <Button
+                    size="sm"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      handleBlur()
+                    }}
+                    className="h-8 px-3 rounded-lg bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 transition-colors flex items-center gap-1.5"
+                  >
+                    <Check className="h-3.5 w-3.5" />
+                    <span className="text-xs font-bold">Done</span>
+                  </Button>
+                </div>
+              </div>
             ) : (
               <>
                 <div

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,17 +5,17 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-xs font-bold ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-3.5 [&_svg]:shrink-0 active:scale-[0.98] border",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-xs font-bold ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-3.5 [&_svg]:shrink-0 active:scale-[0.96] border",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground border-primary/40 shadow-soft hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5",
+        default: "bg-primary text-primary-foreground border-primary/40 shadow-soft hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5 active:shadow-inner",
         destructive:
-          "bg-destructive text-destructive-foreground border-destructive/40 shadow-soft hover:bg-destructive/90 hover:shadow-md hover:-translate-y-0.5",
+          "bg-destructive text-destructive-foreground border-destructive/40 shadow-soft hover:bg-destructive/90 hover:shadow-md hover:-translate-y-0.5 active:shadow-inner",
         outline:
-          "border-border bg-card shadow-soft hover:bg-accent hover:text-accent-foreground hover:border-border hover:shadow-md hover:-translate-y-0.5",
+          "border-border bg-card shadow-soft hover:bg-accent hover:text-accent-foreground hover:border-border hover:shadow-md hover:-translate-y-0.5 active:bg-accent/80",
         secondary:
-          "bg-secondary text-secondary-foreground border-border shadow-soft hover:bg-secondary/80 hover:shadow-md hover:-translate-y-0.5",
+          "bg-secondary text-secondary-foreground border-border shadow-soft hover:bg-secondary/80 hover:shadow-md hover:-translate-y-0.5 active:bg-secondary/60",
         ghost: "border-transparent hover:bg-accent/50 hover:text-accent-foreground hover:border-border",
         link: "border-transparent text-primary underline-offset-4 hover:underline",
       },

--- a/components/ui/editable-text.tsx
+++ b/components/ui/editable-text.tsx
@@ -84,20 +84,15 @@ export function EditableText({
   }
 
   return (
-    <div className="group flex items-center gap-2 max-w-full">
+    <Component className={cn("group flex items-center gap-2 max-w-full", className)}>
       <button
         id={id}
         type="button"
         onClick={() => setIsEditing(true)}
         aria-label={ariaLabel ? `Edit ${ariaLabel}` : (value ? `Edit ${value}` : "Edit empty text")}
-        className={cn(
-          "text-left cursor-pointer hover:bg-accent/20 rounded px-2 py-1 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 border border-primary/10 hover:border-primary/30 min-w-[40px] truncate outline-none w-auto",
-          className
-        )}
+        className="text-left cursor-pointer hover:bg-accent/20 rounded px-1.5 py-0.5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 border border-transparent hover:border-primary/20 min-w-[20px] truncate outline-none"
       >
-        <Component className="inline">
-          {value || <span className="text-muted-foreground italic text-xs font-normal">Empty</span>}
-        </Component>
+        {value || <span className="text-muted-foreground italic text-xs font-normal">Empty</span>}
       </button>
       {showEditIcon && (
         <Pencil
@@ -106,6 +101,6 @@ export function EditableText({
           title="Click to edit"
         />
       )}
-    </div>
+    </Component>
   )
 }

--- a/tests/app.spec.ts
+++ b/tests/app.spec.ts
@@ -39,7 +39,7 @@ test('exporting works', async ({ page }) => {
 
   // Trigger a download (e.g., TXT)
   const downloadPromise = page.waitForEvent('download');
-  await page.getByRole('button', { name: /text/i }).click();
+  await page.getByRole('button', { name: 'TEXT', exact: true }).click();
   const download = await downloadPromise;
 
   expect(download.suggestedFilename()).toContain('.txt');


### PR DESCRIPTION
This PR implements several practical enhancements focused on UX, performance, and accessibility.

Key changes:
1. **Performance**: `OutlineBlock` now uses local `tempContent` state during editing. This debounces updates to the global state, preventing expensive re-renders of the entire outline on every keystroke.
2. **UX & Affordances**: 
   - Added a "Done" button to the `OutlineBlock` editing state for clearer exit intent, especially on mobile.
   - Implemented `Ctrl+Enter` as a save shortcut and `Escape` to revert changes.
   - Added a "Copied!" feedback state to the `ExportModal` to confirm successful clipboard actions.
3. **Accessibility**: Refactored `EditableText` to ensure heading elements (`h1-h4`) correctly wrap the trigger button, fixing invalid nested interactive elements and providing better semantic structure for screen readers.
4. **Reliability**: Updated Playwright tests to ensure compatibility with the new UI elements.

---
*PR created automatically by Jules for task [66135916781303657](https://jules.google.com/task/66135916781303657) started by @allemandi*