### PR TITLE
🔧 Refine: improve interactive affordances, event handling, and export modal UX

### DIFF
--- a/components/export-modal.tsx
+++ b/components/export-modal.tsx
@@ -18,7 +18,13 @@ interface ExportModalProps {
 }
 
 export function ExportModal({ onExport, onCopy }: ExportModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const [copiedFormat, setCopiedFormat] = useState<string | null>(null);
+
+  const handleExport = (format: "pdf" | "docx" | "txt" | "md") => {
+    onExport(format);
+    setIsOpen(false);
+  };
 
   const handleCopy = async (format: "txt" | "md") => {
     onCopy(format);
@@ -27,7 +33,7 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
   };
 
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="h-8 px-2 sm:px-3 rounded-lg font-bold text-[10px] sm:text-xs">
           <Download className="h-3 w-3 sm:h-3.5 sm:w-3.5 mr-1 sm:mr-1.5" />
@@ -43,7 +49,7 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
         </DialogHeader>
         <div className="grid grid-cols-2 gap-3 mt-6">
           <Button
-            onClick={() => onExport("pdf")}
+            onClick={() => handleExport("pdf")}
             variant="outline"
             className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-red-500/[0.03] hover:border-red-500/20"
           >
@@ -51,7 +57,7 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
             <span className="text-[11px] font-bold tracking-widest">PDF</span>
           </Button>
           <Button
-            onClick={() => onExport("docx")}
+            onClick={() => handleExport("docx")}
             variant="outline"
             className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-blue-500/[0.03] hover:border-blue-500/20"
           >
@@ -60,7 +66,7 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
           </Button>
           <div className="flex flex-col gap-2">
             <Button
-              onClick={() => onExport("txt")}
+              onClick={() => handleExport("txt")}
               variant="outline"
               className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-slate-500/[0.03] hover:border-slate-500/20 w-full"
             >
@@ -82,7 +88,7 @@ export function ExportModal({ onExport, onCopy }: ExportModalProps) {
           </div>
           <div className="flex flex-col gap-2">
             <Button
-              onClick={() => onExport("md")}
+              onClick={() => handleExport("md")}
               variant="outline"
               className="h-20 flex-col items-center justify-center rounded-xl p-4 transition-all hover:bg-emerald-500/[0.03] hover:border-emerald-500/20 w-full"
             >

--- a/components/outline-block.tsx
+++ b/components/outline-block.tsx
@@ -187,6 +187,7 @@ export function OutlineBlock({
                   </span>
                   <Button
                     size="sm"
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={(e) => {
                       e.preventDefault()
                       handleBlur()
@@ -228,15 +229,18 @@ export function OutlineBlock({
                     )}
                   </div>
                 </div>
-                <div className="absolute right-3 top-3 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover/content:opacity-100 transition-opacity">
+                <div className="absolute right-3 top-3 flex items-center gap-1 opacity-100 sm:opacity-0 sm:group-hover/content:opacity-100 transition-opacity z-10">
                   {block.content && (
                     <Button
                       variant="ghost"
                       size="icon"
-                      onClick={() => onChange(blockIndex, "")}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onChange(blockIndex, "")
+                      }}
                       className="h-6 w-6 text-muted-foreground/40 hover:text-destructive hover:bg-destructive/5 rounded-md"
                       title="Clear Content"
-                      aria-label="Clear block content"
+                      aria-label={`Clear content for ${block.label}`}
                     >
                       <X className="h-3 w-3" />
                     </Button>
@@ -244,10 +248,13 @@ export function OutlineBlock({
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={() => setIsEditing(true)}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setIsEditing(true)
+                    }}
                     className="h-6 w-6 text-primary/40 hover:text-primary hover:bg-primary/5 rounded-md"
                     title="Edit Content"
-                    aria-label="Edit block content"
+                    aria-label={`Edit content for ${block.label}`}
                   >
                     <Pencil className="h-3 w-3" />
                   </Button>

--- a/components/ui/editable-text.tsx
+++ b/components/ui/editable-text.tsx
@@ -84,23 +84,24 @@ export function EditableText({
   }
 
   return (
-    <Component className={cn("group flex items-center gap-2 max-w-full", className)}>
+    <Component className={cn("group inline-flex items-center max-w-full", className)}>
       <button
         id={id}
         type="button"
         onClick={() => setIsEditing(true)}
         aria-label={ariaLabel ? `Edit ${ariaLabel}` : (value ? `Edit ${value}` : "Edit empty text")}
-        className="text-left cursor-pointer hover:bg-accent/20 rounded px-1.5 py-0.5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 border border-transparent hover:border-primary/20 min-w-[20px] truncate outline-none"
+        className="inline-flex items-center gap-2 text-left cursor-pointer hover:bg-accent/20 rounded px-1.5 py-0.5 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 border border-transparent hover:border-primary/20 min-w-[20px] max-w-full outline-none"
       >
-        {value || <span className="text-muted-foreground italic text-xs font-normal">Empty</span>}
+        <span className="truncate">
+          {value || <span className="text-muted-foreground italic text-xs font-normal">Empty</span>}
+        </span>
+        {showEditIcon && (
+          <Pencil
+            className="h-3 w-3 text-primary/40 opacity-100 sm:opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex-shrink-0"
+            aria-hidden="true"
+          />
+        )}
       </button>
-      {showEditIcon && (
-        <Pencil
-          className="h-3 w-3 text-primary/40 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity flex-shrink-0"
-          aria-hidden="true"
-          title="Click to edit"
-        />
-      )}
     </Component>
   )
 }


### PR DESCRIPTION
🔧 Refine: improve interactive affordances, event handling, and export modal UX

### What
- **Editable Text Affordance**: Moved the edit `Pencil` icon inside the `<button>` element in `components/ui/editable-text.tsx` so clicking the pencil icon directly triggers edit mode and keyboard focus encompasses the icon.
- **Block Action Isolation & Blur Safety**: Added `e.stopPropagation()` to quick action buttons (Clear/Edit) in `components/outline-block.tsx` to prevent accidental click propagation, added `z-10` to action button wrapper, added `onMouseDown={(e) => e.preventDefault()}` on the "Done" save button to avoid blur race conditions, and enhanced ARIA labels.
- **Export Modal UX**: Added controlled open state management to `components/export-modal.tsx` so downloading an export format automatically closes the dialog, matching `BackupModal`.

### Why
- Prevents accidental block content edit mode toggling when attempting to clear content.
- Improves accessibility and keyboard control semantics for inline editing.
- Creates a cleaner, more intuitive modal flow when exporting outlines.

### Impact
- Smoother user interaction and improved visual & keyboard accessibility across block editing and exporting workflows.

---
*PR created automatically by Jules for task [16987544886949591660](https://jules.google.com/task/16987544886949591660) started by @allemandi*