### PR TITLE
Fix CLI pipeline issues and ensure compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
             ${{ runner.os }}-playwright-
       - name: Install Playwright Browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium webkit
+        run: |
+          npx playwright install chromium webkit
+          npx playwright install-deps chromium webkit
       - name: Install Playwright dependencies
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium webkit

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "playwright": "^1.59.0",
     "postcss": "^8.5.24",
     "tailwindcss": "^4.2.2",
-    "typescript": "^7.0.2"
+    "typescript": "7.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,7 +3902,7 @@ typescript-eslint@^8.46.0:
     "@typescript-eslint/typescript-estree" "8.57.0"
     "@typescript-eslint/utils" "8.57.0"
 
-typescript@^7.0.2:
+typescript@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-7.0.2.tgz#9ec773d7954a8c182c17cc5bbd575aa28bc51582"
   integrity sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==


### PR DESCRIPTION
Fix CLI pipeline issues by updating `.github/workflows/ci.yml` to separate Playwright browser binary installation and system dependency installation.

---
*PR created automatically by Jules for task [13930869629654120073](https://jules.google.com/task/13930869629654120073) started by @allemandi*