### PR TITLE
Fix and simplify CI pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn lint
 
@@ -40,16 +31,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Upload build artifact
@@ -68,16 +50,7 @@ jobs:
         with:
           node-version: 20
           cache: 'yarn'
-      - name: Cache node modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-modules-
       - name: Install dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -97,14 +70,8 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          npx playwright install chromium webkit
-          npx playwright install-deps chromium webkit
-      - name: Install Playwright dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium webkit
+      - name: Install Playwright Browsers & Dependencies
+        run: npx playwright install --with-deps chromium webkit
       - run: yarn test
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Fixed broken CI build and test steps by removing redundant node_modules cache steps that bypassed yarn install and caused missing dependency links. Simplified Playwright installation step to use playwright install --with-deps.

---
*PR created automatically by Jules for task [18172744111268840192](https://jules.google.com/task/18172744111268840192) started by @allemandi*