### PR TITLE
Fix CI build failures from `@types/node` and `typescript` upgrades

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     template: `%s | ${SITE_CONFIG.name}`,
   },
   description: SITE_CONFIG.description,
-  keywords: SITE_CONFIG.keywords,
+  keywords: [...SITE_CONFIG.keywords],
   authors: [{ name: SITE_CONFIG.author, url: SITE_CONFIG.github }],
   creator: SITE_CONFIG.author,
   alternates: { canonical: "/" },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-    darkMode: ["class"],
+    darkMode: "class",
     content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
Resolved TypeScript type errors resulting from upgrading `@types/node` and `typescript`.
- Updated `app/layout.tsx` to spread `SITE_CONFIG.keywords` as a mutable array `string[]` to satisfy `Metadata` type definitions.
- Updated `tailwind.config.ts` to set `darkMode: "class"` to match Tailwind `Config` type requirements.

---
*PR created automatically by Jules for task [3503942610054340592](https://jules.google.com/task/3503942610054340592) started by @allemandi*